### PR TITLE
feat: Adding support for basher install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ The `column` utillity as well as `sed` are needed for this script to work.
 
 The implementation has been tested using *bash* as well as *zsh*.
 
+## Installation
+
+Options
+
+* Copy and paste the code in your script
+* Download it and chmod +x the script then save it somewhere on your PATH and source it
+* If you have [basher](https://github.com/basherpm/basher) then `basher install jakobwesthoff/prettytable.sh`
+
 ## Usage
 
 You may either source the `prettytable.sh` file or use it as an executable.
 Both works just fine.
+See [Installation](#installation) for install options.
 
 Multiline table data is simply piped into `prettytable` for formating, while
 the number of columns needs to be specified. Columns need to be delimited using

--- a/prettytable
+++ b/prettytable
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ####
-# Copyright (c) 2016-2021 
+# Copyright (c) 2016-2021
 #   Jakob Westhoff <jakob@westhoffswelt.de>
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #  - Redistributions of source code must retain the above copyright notice, this
 #    list of conditions and the following disclaimer.
 #  - Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE


### PR DESCRIPTION
* Updated shebang to use env so that defaul bash shell is used instead of hardcoding the /bin/bash since macos users often install newer bash versions via [homebrew](https://brew.sh/).
* Changed permissions on perttytable.sh to be executable so that basher will install it into the users path.
* Changed prettytable.sh to prettytable to avoid difference between source parameter and executable use.
* Updated the README.md to specify installation methods including basher.

Fixes: Issue #5