### PR TITLE
Avoid cat when possible, give some air to every column

### DIFF
--- a/prettytable
+++ b/prettytable
@@ -36,7 +36,7 @@ _prettytable_char_vertical_horizontal_right="┤"
 _prettytable_char_vertical_horizontal_top="┬"
 _prettytable_char_vertical_horizontal_bottom="┴"
 _prettytable_char_vertical_horizontal="┼"
-
+_prettytable_char_filler="\u2002" # En-Space
 
 # Escape codes
 
@@ -62,11 +62,11 @@ _prettytable_color_white="1;37"
 _prettytable_color_none="0"
 
 function _prettytable_prettify_lines() {
-    cat - | sed -e "s@^@${_prettytable_char_vertical}@;s@\$@	@;s@	@	${_prettytable_char_vertical}@g"
+    sed -e "s@^@ ${_prettytable_char_vertical} @;s@\$@	@;s@	@	 ${_prettytable_char_vertical} @g"
 }
 
 function _prettytable_fix_border_lines() {
-    cat - | sed -e "1s@ @${_prettytable_char_horizontal}@g;3s@ @${_prettytable_char_horizontal}@g;\$s@ @${_prettytable_char_horizontal}@g"
+    sed -e "1s@ @${_prettytable_char_horizontal}@g;3s@ @${_prettytable_char_horizontal}@g;\$s@ @${_prettytable_char_horizontal}@g"
 }
 
 function _prettytable_colorize_lines() {
@@ -74,40 +74,40 @@ function _prettytable_colorize_lines() {
     local range="$2"
     local ansicolor="$(eval "echo \${_prettytable_color_${color}}")"
 
-    cat - | sed -e "${range}s@\\([^${_prettytable_char_vertical}]\\{1,\\}\\)@"$'\E'"[${ansicolor}m\1"$'\E'"[${_prettytable_color_none}m@g"
+    sed -e "${range}s@\\([^${_prettytable_char_vertical}]\\{1,\\}\\)@"$'\E'"[${ansicolor}m\1"$'\E'"[${_prettytable_color_none}m@g"
 }
 
 function prettytable() {
     local cols="${1}"
     local color="${2:-none}"
-    local input="$(cat -)"
+    input=$(< /dev/stdin)
     local header="$(head -n1 <<<${input})"
     local body="$(tail -n+2 <<<${input})"
     {
         # Top border
-        printf "${_prettytable_char_top_left}"
+        printf "${_prettytable_char_filler}${_prettytable_char_top_left}"
         for i in $(seq 2 ${cols}); do
-            printf "\t%s" "${_prettytable_char_vertical_horizontal_top}"
+            printf "\t%s" "${_prettytable_char_horizontal}${_prettytable_char_vertical_horizontal_top}${_prettytable_char_horizontal}"
         done
-        printf "\t%s\n" "${_prettytable_char_top_right}"
+        printf "\t%s\n" "${_prettytable_char_horizontal}${_prettytable_char_top_right}"
 
         printf "%s\n" "${header}" | _prettytable_prettify_lines
 
         # Header/Body delimiter
-        printf "${_prettytable_char_vertical_horizontal_left}"
+        printf "${_prettytable_char_filler}${_prettytable_char_vertical_horizontal_left}"
         for i in $(seq 2 ${cols}); do
-            printf "\t%s" "${_prettytable_char_vertical_horizontal}"
+            printf "\t%s" "${_prettytable_char_horizontal}${_prettytable_char_vertical_horizontal}${_prettytable_char_horizontal}"
         done
-        printf "\t%s\n" "${_prettytable_char_vertical_horizontal_right}"
+        printf "\t%s\n" "${_prettytable_char_horizontal}${_prettytable_char_vertical_horizontal_right}"
 
         printf "%s\n" "${body}" | _prettytable_prettify_lines
 
         # Bottom border
-        printf "${_prettytable_char_bottom_left}"
+        printf "${_prettytable_char_filler}${_prettytable_char_bottom_left}"
         for i in $(seq 2 ${cols}); do
-            printf "\t%s" "${_prettytable_char_vertical_horizontal_bottom}"
+            printf "\t%s" "${_prettytable_char_horizontal}${_prettytable_char_vertical_horizontal_bottom}${_prettytable_char_horizontal}"
         done
-        printf "\t%s\n" "${_prettytable_char_bottom_right}"
+        printf "\t%s\n" "${_prettytable_char_horizontal}${_prettytable_char_bottom_right}"
     } | column -o '' -t -s $'\t' | _prettytable_fix_border_lines | _prettytable_colorize_lines "${color}" "2"
 }
 


### PR DESCRIPTION
Less external processes by taking out some cases of avoidable `cat` commands. And let every column sport one space before and one space after its widest cell, based on the aesthetics of NuShell